### PR TITLE
Got rid of a race condition on initialization. Fixed app termination.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,12 @@
 #include <thread>
 #include <SDL2/SDL.h>
 
+#ifdef _WIN32
+	#define NOMINMAX 1
+	#define WIN32_LEAN_AND_MEAN
+	#include <Windows.h>
+#endif // _WIN32
+
 class Renderer
 {
 public:
@@ -117,7 +123,7 @@ void Renderer::renderJob()
     }
 }
 
-int main()
+int main(int argc, char **argv)
 {
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
 
@@ -144,3 +150,13 @@ int main()
 
     return 0;
 }
+
+#ifdef __MINGW32__
+
+// MinGW expects a WinMain().
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevIns, LPSTR lpszArgument, int iShow)
+{
+	return main(0, nullptr);
+}
+
+#endif // __MINGW32__


### PR DESCRIPTION
Thank you for making this code sample!

I need to port a very large set of OpenGL applications from Windows to Linux, and so far, it looks like SDL2 is my best bet.
But among our many constraints, we run rendering in a separate thread, so I had to make sure SDL2 could do that.
Your code sample randomly crashed in SDL_SendWindowEvent() on startup.
Finally, I figured out the renderer had to be initialized before SDL_PollEvent() could be called safely.
I made a few other improvements too, e.g. fixed app termination, and minimized CPU usage.